### PR TITLE
Reflecting connection to view binding in menu

### DIFF
--- a/Extempore.sublime-commands
+++ b/Extempore.sublime-commands
@@ -1,5 +1,6 @@
 [
     { "caption": "Extempore: Connect", "command": "extempore_connect" },
+    { "caption": "Extempore: Evaluate", "command": "extempore_evaluate" },
     { "caption": "Extempore: Disconnect", "command": "extempore_disconnect" },
-    { "caption": "Extempore: Evaluate", "command": "extempore_evaluate" }
+    { "caption": "Extempore: Disconnect all", "command": "extempore_disconnect_all" },
 ]

--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -9,8 +9,9 @@
 				"children":
 				[
 					{ "caption": "Connect...", "command": "extempore_connect" },
-					{ "caption": "Evaluate...", "command": "extempore_evaluate" },
-					{ "caption": "Disconnect...", "command": "extempore_disconnect" }
+					{ "caption": "Evaluate", "command": "extempore_evaluate" },
+					{ "caption": "Disconnect", "command": "extempore_disconnect" },
+					{ "caption": "Disconnect All", "command": "extempore_disconnect_all" }
 				]
 			}
 		]


### PR DESCRIPTION
Hi!

I have noticed a few problems while using the plugin, looking at the source I found out that the connections are bound to the current view but the commands in the menu don't reflect this properly. Also, I found out that the connection for the current view is not being closed if the view is closed.

Changes:
* ”Connect” now is only available if the view syntax is set to Extempore
* “Disconnect” now disconnects only current view's connections and is only available if the view has bound connections
* “Disconnect all” command is added and is only available if there are any connections
* ”Evaluate” now is only available if the view has bound connections
* Connections for the current view are now being closed on the view close